### PR TITLE
Fix typo in link on home page

### DIFF
--- a/_pages/home.md
+++ b/_pages/home.md
@@ -98,7 +98,7 @@ Choose the build for your platform:
 1. **Download the environment**
 2. **Install dependencies**
 3. **Train your first agent** 
-4. **Submit your model** — Package your trained models and follow the **[Submission Guide](submission_guide)**.
+4. **Submit your model** — Package your trained models and follow the **[Submission Guide](submission-guide)**.
 
 
 ## Competition Tracks


### PR DESCRIPTION
The link to the Submission Guide on the home page has an underscore in it instead of a hyphen, resulting in a 404. 